### PR TITLE
fix "division by zero" error thrown by widget if no order exists

### DIFF
--- a/src/widgets/Comparison.php
+++ b/src/widgets/Comparison.php
@@ -110,6 +110,9 @@ class Comparison extends Widget
 			])
 			->count();
 
+		if (!$total) 
+			return $p = 0;
+
 		$wp = (new Query())
 			->from('{{%web_payments}} wp')
 			->leftJoin(


### PR DESCRIPTION
return 0 percent in web payments comparison widget if no order exists – Fixes #17